### PR TITLE
Removing vendor.js as not needed

### DIFF
--- a/website/config/base.config.js
+++ b/website/config/base.config.js
@@ -21,8 +21,7 @@ module.exports={
         main:["babel-polyfill","./entry.js"],
         check:["./js/browser-check.js"],
         client:["babel-polyfill","./js/client.js"],
-        test:["babel-polyfill","./js/test.js"],
-        vendor:["aws-sdk"]
+        test:["babel-polyfill","./js/test.js"]
     },
     output:{
         path:path.join(__dirname,'../build'),
@@ -39,7 +38,7 @@ module.exports={
         new HtmlWebpackPlugin({
             template:'./html/admin.pug',
             filename:'index.html',
-            chunks:["main","check","vendor"]
+            chunks:["main","check"]
         }),
         new HtmlWebpackPlugin({
             template:'./html/test.ejs',
@@ -49,7 +48,7 @@ module.exports={
         new HtmlWebpackPlugin({
             template:'./html/client.pug',
             filename:'client.html',
-            chunks:["client","vendor"]
+            chunks:["client"]
         }),
         new HtmlWebpackPlugin({
             filename:"health.html",


### PR DESCRIPTION
webpack is building a separate vendor.js file containing the aws sdk. However the aws sdk is loaded in separately from CDN so the vendor package is not needed. This should give around a 337Kb saving and a network request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
