### PR TITLE
BUGFIX: Correct Kendra Web crawler Makefile

### DIFF
--- a/lambda/kendra-webcrawler/Makefile
+++ b/lambda/kendra-webcrawler/Makefile
@@ -1,5 +1,6 @@
 NAME=$(shell basename $(shell pwd))
 DST=../../build/lambda/$(NAME).zip
 
-echo "Building $(NAME)"; pip3 install -r requirements.txt -t . && zip -r -q $(DST) .
+$(DST): $(RESOURCES) 
+	echo "Building $(NAME)"; pip3 install -r requirements.txt -t . && zip -r -q $(DST) .
 


### PR DESCRIPTION
The Kendra Web Crawler Lambda's makefile has an error that will prevent it from building.  