### PR TITLE
Fix: Kendra FAQ/Test functionality

### DIFF
--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -7,6 +7,8 @@ var kendra = require('./kendraQuery');
 var AWS=require('aws-sdk');
 
 const qnabot = require("qnabot/logging")
+const open_es = require("./es_query")
+
 
 
 function isJson(str) {
@@ -152,14 +154,18 @@ module.exports= async (event, context, callback) => {
         event.minimum_score = _.get(settings, 'ALT_SEARCH_KENDRA_FAQ_CONFIDENCE_SCORE', "MEDIUM")
         var question = _.get(event,'question','');
         var topic = _.get(event,'topic','');
-        // Use kendra only if 
-        // - question is not empty
-        // - question has two or more words
-        // - topic is not set
-        // - and a kendra index is specified
-        // NOTE: Logic must be consistent with query.js function isESOnly() to ensure Content Designer Test tab
-        // and runtime bot question handling behave consistently. 
-        let okKendraQuery = (question.length > 0 && question.split(" ").length  > 1 && topic.length == 0 && kendra_index != "") ;
+       
+        let req = {
+           question: question,    
+        }
+        //TODO: At some point we should expose a qnaClientFilter field in the
+        //Content Designer and pass the value here.
+        let params = {
+            topic: topic,
+            kendraIndex: kendra_index,
+            question: question
+        }
+        let okKendraQuery = !(await open_es.isESonly(req,params))
         if ( okKendraQuery ) {
             var response = await run_query_kendra(event, kendra_index);
             // ES fallback if KendraFAQ fails
@@ -175,12 +181,12 @@ module.exports= async (event, context, callback) => {
         qnabot.log("Query response: ", JSON.stringify(response,null,2));
         return callback(null, response);
     } catch (error) {
-        qnabot.log(`error is ${JSON.stringify(error, null,2)}`);
+        
         return callback(JSON.stringify({
-            type:error.response.status===404 ? "[NotFound]":"[InternalServiceError]",
-            status:error.response.status,
-            message:error.response.statusText,
-            data:error.response.data
+            type:_.get(error,"response.status") ===404 ? "[NotFound]":"[InternalServiceError]",
+            status:_.get(error,"response.status"),
+            message:_.get(error,"response.statusText"),
+            data:_.get(error,"response.data")
         }))
     }
 }

--- a/lambda/es-proxy-layer/lib/kendraQuery.js
+++ b/lambda/es-proxy-layer/lib/kendraQuery.js
@@ -133,7 +133,7 @@ async function routeKendraRequest(request_params) {
                 if (element.Type === 'QUESTION_ANSWER' && foundAnswerCount < request_params.size && element.AdditionalAttributes &&
                     element.AdditionalAttributes.length > 1) {
 
-                    if (!open.es.hasJsonStructure(element.DocumentURI)) {
+                    if (!open_es.hasJsonStructure(element.DocumentURI)) {
                         break;
                     }
                     var hit = JSON.parse(element.DocumentURI);
@@ -149,7 +149,7 @@ async function routeKendraRequest(request_params) {
                             continue;
 
                         }
-                        if(_.get(hit,"clientFilterValues","") == ""){
+                        if(_.get(hit,"QNAClientFilter")){
                             qnabot.log("Found an answer with a clientFilterValue set...skipping")
                             continue;
                         }

--- a/lambda/es-proxy-layer/lib/query.js
+++ b/lambda/es-proxy-layer/lib/query.js
@@ -19,10 +19,11 @@ var encryptor = require('simple-encryptor')(key);
 
 
 async function run_query(req, query_params) {
-    var onlyES = await isESonly(req, query_params);
+    query_params.kendraIndex = _.get(req, "_settings.KENDRA_FAQ_INDEX")
+    var onlyES = await open_es.isESonly(req, query_params);
     let response = "";
     // runs kendra query if question supported on Kendra and KENDRA_FAQ_INDEX is set
-   if (!onlyES && _.get(req, "_settings.KENDRA_FAQ_INDEX")!=""){
+   if (!onlyES){
         response= await run_query_kendra(req, query_params);
     } 
     else {
@@ -31,35 +32,6 @@ async function run_query(req, query_params) {
     qnabot.log(`response ${JSON.stringify(response)}` )
     return response;
 }
-
-async function isESonly(req, query_params) {
-    // returns boolean whether question is supported only on ElasticSearch
-    // no_hits is ES only
-    var no_hits_question = _.get(req, '_settings.ES_NO_HITS_QUESTION', 'no_hits');
-    var ES_only_questions = [no_hits_question];
-    if (ES_only_questions.includes(query_params['question'])) {
-        return true
-    }
-    // QID querying is ES only
-    if (query_params.question.toLowerCase().startsWith("qid::")) {
-        return true
-    }
-    // setting topics is ES only
-    if (_.get(query_params, 'topic')!="") {
-        return true
-    }
-    // setting clientFilterValues should block Kendra FAQ indexing
-    if (_.get(query_params, 'qnaClientFilter')!="") {
-        return true
-    }    
-    //Don't send one word questions to Kendra
-    if(query_params.question.split(" ").length  < 2){
-        return true;
-    }
-    return false;
-}
-
-
 
 
 async function run_query_kendra(req, query_params) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Corrects API error when using the Test Feature with Kendra FAQ Sync enabled
- Consolidates isESOnly logic that determines when Kendra FAQ should not be used
- Corrects isESOnly logic
- Corrects client filter behavior when using Kendra FAQ

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
