### PR TITLE
handling response card images with long URLs

### DIFF
--- a/lambda/fulfillment/lib/middleware/lex.js
+++ b/lambda/fulfillment/lib/middleware/lex.js
@@ -425,14 +425,24 @@ function assembleLexV2Response(request, response) {
         out = getV2CloseTemplate(request, response); 
         
     }
-    
-    if (! isConnectClient(request) ){
+
+    if (!isConnectClient(request)){
         let imageResponseCardV2 = buildImageResponseCardV2(response);
-        if (imageResponseCardV2) {
-            out.messages[1] = {
-                "contentType": "ImageResponseCard",
-                "imageResponseCard": imageResponseCardV2            
-            };
+        if(imageResponseCardV2) {
+              let imgUrlLength = imageResponseCardV2.imageUrl.length
+              qnabot.log("image URL length suraj : ")
+              qnabot.log(imgUrlLength)
+              let client = _.get(request,"_clientType", undefined)
+              qnabot.log("Client Type suraj : ")
+              qnabot.log(client)
+              if(imgUrlLength > 250){
+                  qnabot.log("ResponseCard Image URL length is greater than the max limit (250 chars). Client is LexWebUI. Sending ResponseCard as session attribute rather than as Lex ImageresponseCard to avoid hitting the Lex URL length limit.")
+              } else { 
+                  out.messages[1] = {
+                      "contentType": "ImageResponseCard",
+                      "imageResponseCard": imageResponseCardV2            
+                    };
+              }
         }
     }
     

--- a/lambda/fulfillment/lib/middleware/lex.js
+++ b/lambda/fulfillment/lib/middleware/lex.js
@@ -430,11 +430,7 @@ function assembleLexV2Response(request, response) {
         let imageResponseCardV2 = buildImageResponseCardV2(response);
         if(imageResponseCardV2) {
               let imgUrlLength = imageResponseCardV2.imageUrl.length
-              qnabot.log("image URL length suraj : ")
-              qnabot.log(imgUrlLength)
               let client = _.get(request,"_clientType", undefined)
-              qnabot.log("Client Type suraj : ")
-              qnabot.log(client)
               if(imgUrlLength > 250){
                   qnabot.log("ResponseCard Image URL length is greater than the max limit (250 chars). Client is LexWebUI. Sending ResponseCard as session attribute rather than as Lex ImageresponseCard to avoid hitting the Lex URL length limit.")
               } else { 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding condition to check if the image URL length for the response card is > 250 characters. If so, log a message about the limit and not add the card to the lex response. If URL length is <250 characters, adding the card to the lex response. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
