### PR TITLE
Feature/catchall when no topic

### DIFF
--- a/lambda/es-proxy-layer/lib/esbodybuilder.js
+++ b/lambda/es-proxy-layer/lib/esbodybuilder.js
@@ -104,11 +104,40 @@ function build_query(params) {
       if (_.get(params, 'score_answer_field')) {
         query = query.orQuery('match', 'a', params.question);
       }
-      query = query.orQuery('match', 't', _.get(params, 'topic', ''))
+      let topic = _.get(params, 'topic');
+      if (topic) {
+        query = query.orQuery('match', 't', topic);
+      } else {
+        // no topic - query prefers answers with empty/missing topic field for predicable response
+        // NOTE: will not work in Kendra FAQ mode since we have no equivalent Kendra query
+        query = query.orQuery(
+          'bool', {
+            "should" : [
+              { 
+                "match_all": {
+                } 
+              },
+              {
+                "bool": {
+                  "must_not": [
+                      {
+                          "exists": {
+                              "field": "t"
+                          }
+                      }
+                  ]
+                }
+              }          
+            ],
+            "minimum_should_match" : 2
+          }      
+        ) ;
+      }
+      query = query
         .from(_.get(params, 'from', 0))
         .size(_.get(params, 'size', 1))
         .build();
-      qnabot.log("ElasticSearch Query", JSON.stringify(query, null, 2));
+      qnabot.log("ElasticSearch Query: ", JSON.stringify(query, null, 2));
       return new Promise.resolve(query);
     });
     }

--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -85,9 +85,6 @@ async function get_es_query(event, settings) {
             score_answer_field: _.get(settings,'ES_SCORE_ANSWER_FIELD'),
             fuzziness: _.get(settings, 'ES_USE_FUZZY_MATCH'),
             es_expand_contractions: _.get(settings,"ES_EXPAND_CONTRACTIONS"),
-
-
-
         };
         return build_es_query(query_params);
     } else {
@@ -98,14 +95,12 @@ async function get_es_query(event, settings) {
 
 
 async function run_query_es(event, settings) {
-    qnabot.log("ElasticSearch Query",JSON.stringify(es_query,null,2));
     var es_query = await get_es_query(event, settings);
     var es_response = await request({
         url:Url.resolve("https://"+event.endpoint,event.path),
         method:event.method,
         headers:event.headers,
         body:es_query,
-
     });
     return es_response;
 }


### PR DESCRIPTION
*Issue #, if available:* #436

*Description of changes:* Implements small score boost for items with no topic when topic is not set in the query. This breaks the ties, and allows a predictable response for an ambiguous question when there is no topic, by preferring an answer that also has no topic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
