### PR TITLE
Fix/stopword only query

### DIFF
--- a/lambda/es-proxy-layer/lib/es_query.js
+++ b/lambda/es-proxy-layer/lib/es_query.js
@@ -83,9 +83,17 @@ async function run_qid_query_es(params, qid) {
     }
 }
 
+function isQuestionAllStopwords(question) {
+    let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
+    let questionwords = question.toLowerCase().match(/\b(\w+)\b/g)
+    let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
+    return allStopwords;
+}
+
 module.exports = {
     run_query_es:run_query_es,
     run_qid_query_es:run_qid_query_es,
     hasJsonStructure:hasJsonStructure,
-    isESonly:isESonly
+    isESonly:isESonly,
+    isQuestionAllStopwords:isQuestionAllStopwords
 }

--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -68,9 +68,20 @@ async function get_settings() {
     return settings;
 }
 
+function isQuestionAllStopwords(question) {
+    // TODO define stopwords once in shared module
+    let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
+    let questionwords = question.toLowerCase().match(/\b(\w+)\b/g)
+    let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
+    return allStopwords;
+}
 
 async function get_es_query(event, settings) {
     var question = _.get(event,'question','');
+    if (isQuestionAllStopwords(question)) {
+        console.log(`Question '${question}' contains only stop words. Returning no_hits response.`);
+        question = _.get(settings, 'ES_NO_HITS_QUESTION', 'no_hits');       
+    }
     if (question.length > 0) {
         var query_params = {
             question: question,
@@ -85,9 +96,6 @@ async function get_es_query(event, settings) {
             score_answer_field: _.get(settings,'ES_SCORE_ANSWER_FIELD'),
             fuzziness: _.get(settings, 'ES_USE_FUZZY_MATCH'),
             es_expand_contractions: _.get(settings,"ES_EXPAND_CONTRACTIONS"),
-
-
-
         };
         return build_es_query(query_params);
     } else {

--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -68,17 +68,9 @@ async function get_settings() {
     return settings;
 }
 
-function isQuestionAllStopwords(question) {
-    // TODO define stopwords once in shared module
-    let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
-    let questionwords = question.toLowerCase().match(/\b(\w+)\b/g)
-    let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
-    return allStopwords;
-}
-
 async function get_es_query(event, settings) {
     var question = _.get(event,'question','');
-    if (isQuestionAllStopwords(question)) {
+    if (open_es.isQuestionAllStopwords(question)) {
         console.log(`Question '${question}' contains only stop words. Returning no_hits response.`);
         question = _.get(settings, 'ES_NO_HITS_QUESTION', 'no_hits');       
     }

--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -107,7 +107,7 @@ async function run_query_es(event, settings) {
         headers:event.headers,
         body:es_query,
     });
-    if (es_response.hits.max_score == 0) {
+    if (_.get(es_response, "hits.max_score") == 0) {
         qnabot.log("Max score is zero - no valid results")
         es_response.hits.hits = [] ;
     }

--- a/lambda/es-proxy-layer/lib/handler.js
+++ b/lambda/es-proxy-layer/lib/handler.js
@@ -71,11 +71,11 @@ async function get_settings() {
 async function get_es_query(event, settings) {
     let question = _.get(event,'question','');
     let size = _.get(event,'size',1);
-    if (open_es.isQuestionAllStopwords(question)) {
-        console.log(`Question '${question}' contains only stop words. Forcing no hits.`);
-        size = 0;
-    }
     if (question.length > 0) {
+        if (open_es.isQuestionAllStopwords(question)) {
+            console.log(`Question '${question}' contains only stop words. Forcing no hits.`);
+            size = 0;
+        }
         var query_params = {
             question: question,
             topic: _.get(event,'topic',''),
@@ -99,8 +99,8 @@ async function get_es_query(event, settings) {
 
 
 async function run_query_es(event, settings) {
-    qnabot.log("ElasticSearch Query",JSON.stringify(es_query,null,2));
     var es_query = await get_es_query(event, settings);
+    qnabot.log("ElasticSearch Query",JSON.stringify(es_query,null,2));
     var es_response = await request({
         url:Url.resolve("https://"+event.endpoint,event.path),
         method:event.method,

--- a/lambda/es-proxy-layer/lib/query.js
+++ b/lambda/es-proxy-layer/lib/query.js
@@ -158,19 +158,10 @@ function merge_next(hit1, hit2) {
     return hit2;
 }
 
-// check if the question contains nothing but ES stopwords.
-function isQuestionAllStopwords(question) {
-    // TODO define stopwords once in shared module
-    let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
-    let questionwords = question.toLowerCase().match(/\b(\w+)\b/g)
-    let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
-    return allStopwords;
-}
-
 async function get_hit(req, res) {
     let question = req.question;
     var no_hits_question = _.get(req, '_settings.ES_NO_HITS_QUESTION', 'no_hits');
-    if (isQuestionAllStopwords(question)) {
+    if (open_es.isQuestionAllStopwords(question)) {
         console.log(`Question '${question}' contains only stop words. Returning no_hits response.`);
         question = no_hits_question;       
     }


### PR DESCRIPTION
Queries containing only stopwords should return no_hits instead of random answer

Issue # , if available: https://github.com/aws-solutions/aws-qnabot/issues/435

Description of changes: Check if question contains only words that are designated as ES stopwords, or is max score in ES result is 0. In either case, force no_hits behavior. (Previously the ES query did not filter results at all, resulting in a random answer being returned.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.