### PR TITLE
Fix metric logging issue when field count exceeds index limit by rais…

### DIFF
--- a/templates/master/elasticsearch/proxy.js
+++ b/templates/master/elasticsearch/proxy.js
@@ -51,7 +51,7 @@ module.exports={
                 index:{"Fn::Sub":"${Var.MetricsIndex}"},
                 endpoint:{"Fn::GetAtt":["ESVar","ESAddress"]},
                 body:{"Fn::Sub":JSON.stringify({
-                    settings:{},
+                    settings:{"index.mapping.total_fields.limit":2000},
                 })}
             }
         }


### PR DESCRIPTION
Fix customer reported issue - metric logging stopped when field count exceeds index limit by raising limit from 1000 to 2000: Limit of total fields [1000] in index X has been exceeded

*Description of changes:*

Added index setting to metrics index to increase total_fileds.limit to 2000 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
