### PR TITLE
Kendra multi language search

### DIFF
--- a/docs/Technical Information.md
+++ b/docs/Technical Information.md
@@ -131,7 +131,7 @@
 
 ## KMS
 - There is an optional utility script which adds KMS/CMK encryption to many resources.  The list below is for the default use cases
-- The quiz workflow - not used by RhodeIsland
+- The quiz workflow.
 
 ## CloudWatch Events
 - KendraCrawlerRule - Schedules the Kendra Crawler based on setting

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,6 +37,7 @@
 | KENDRA_INDEXER_CRAWL_DEPTH | number | Sets the depth to the number of levels in a website from the seed level that you want to crawl
 | KENDRA_INDEXER_CRAWL_MODE | HOST_ONLY \| SUBDOMAINS \| EVERYTHING | Determines which addresses should be crawled
 | KENDRA_WEB_PAGE_INDEX | Kendra Index Id | The index to use for the web crawler, a [custom data source](https://docs.aws.amazon.com/kendra/latest/dg/data-source-custom.html) will automatically be added to the specified index.  
+| KENDRA_INDEXED_DOCUMENTS_LANGUAGES | comma separate list | Should be one of supported Kendra languages mentioned in [documentation](https://docs.aws.amazon.com/kendra/latest/dg/in-adding-languages.html)
 | ERRORMESSAGE | text | Response to the user when a processing error occurs
 | EMPTYMESSAGE | text | Response to the user when an answer could not be found
 | DEFAULT_ALEXA_LAUNCH_MESSAGE | text | Initial greeting when using Alexa

--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -317,12 +317,14 @@ async function routeKendraRequest(event, context) {
         throw new Error('Undefined Kendra Indexes');
     }
 
-    qnabot.log("kendra settings: " + _.get(event.req["_settings"], "KENDRA_INDEXED_DOCUMENTS_LANGUAGES", ["empty"]));
     let kendraIndexedLanguages = _.get(event.req["_settings"],
         "KENDRA_INDEXED_DOCUMENTS_LANGUAGES",["en"]);
+    qnabot.log("Retrieved Kendra multi-language settings: " + kendraIndexedLanguages);
+
     let origQuestion = event.req["_event"]["origQuestion"];
     let question = event.req["question"];
-    let userDetectedLocale = event.req["session"]["userDetectedLocale"];
+    let userDetectedLocale = _.get(event.req, 'session.qnabotcontext.userLocale');
+
     let useOriginalLanguageQuery = kendraIndexedLanguages.includes(userDetectedLocale, 0)
         && origQuestion && question && origQuestion!=question;
     qnabot.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);

--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -287,7 +287,7 @@ async function routeKendraRequest(event, context) {
     let origQuestion = event.req["_event"]["origQuestion"];
     let question = event.req["question"];
     let useOriginalLanguageQuery = origQuestion && question && origQuestion!=question;
-    console.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);
+    qnabot.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);
 
     // if test environment, then use mock-up of kendraClient
     if (event.test) {
@@ -327,7 +327,7 @@ async function routeKendraRequest(event, context) {
     kendraIndexes.forEach(function (index, i) {
         // if results cached from KendraFAQ, skip index by pushing Promise to resolve cached results
         if (kendraResultsCached && index===kendraResultsCached.originalKendraIndexId && !useOriginalLanguageQuery) {
-            console.log(`retrieving cached kendra results`)
+            qnabot.log(`retrieving cached kendra results`)
             promises.push(new Promise(function(resolve, reject) {
                 var data = kendraResultsCached
                 _.set(event.req, "kendraResultsCached", "cached and retrieved");  // cleans the logs
@@ -584,8 +584,7 @@ async function routeKendraRequest(event, context) {
     })
 
     hit.autotranslate = useOriginalLanguageQuery ? false : true;
-    console.log("Returning event: ", JSON.stringify(hit, null, 2));
-
+    qnabot.log("Returning event: ", JSON.stringify(hit, null, 2));
     return hit;
 }
 

--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -82,7 +82,7 @@ function addMarkdownHighlights(textIn,hlBeginOffset,hlEndOffset,highlightOnly=fa
             textOut = '**' + highlight + '**';
         } else {
             textOut = beginning + '**' + highlight + '**' + rest;
-        }        
+        }
     }
     return textOut ;
 }
@@ -152,7 +152,7 @@ function mergeIntervals(intervals) {
     // get the top element
     top = stack[stack.length - 1];
 
-    // if the current interval doesn't overlap with the 
+    // if the current interval doesn't overlap with the
     // stack top element, push it to the stack
     if (top.EndOffset < intervals[i].BeginOffset) {
       stack.push(intervals[i]);
@@ -172,7 +172,7 @@ function mergeIntervals(intervals) {
 
 
 function signS3URL(url, expireSecs) {
-    var bucket, key; 
+    var bucket, key;
     if (url.search(/\/s3[.-](\w{2}-\w{4,9}-\d\.)?amazonaws\.com/) != -1) {
       //bucket in path format
       bucket = url.split('/')[3];
@@ -201,7 +201,7 @@ function signS3URL(url, expireSecs) {
         }
     } else {
         qnabot.log("URL is not an S3 url - return unchanged: ",url);
-    }   
+    }
     return url;
 }
 
@@ -233,7 +233,7 @@ function longestInterval(intervals) {
   } else if (intervals.length == 1) {
     return intervals[0];
   }
-  
+
   // sort the intervals based on their length
   intervals.sort(function(a, b) {return (a[1]-a[0]) - (b[1]-b[0])});
   return intervals[0];
@@ -284,11 +284,6 @@ async function routeKendraRequest(event, context) {
     let resArray = [];
     let kendraClient = undefined;
 
-    let origQuestion = event.req["_event"]["origQuestion"];
-    let question = event.req["question"];
-    let useOriginalLanguageQuery = origQuestion && question && origQuestion!=question;
-    qnabot.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);
-
     // if test environment, then use mock-up of kendraClient
     if (event.test) {
         var mockup = './test/mockClient' + event.test + '.js';
@@ -321,7 +316,17 @@ async function routeKendraRequest(event, context) {
     if (kendraIndexes === undefined) {
         throw new Error('Undefined Kendra Indexes');
     }
-    
+
+    qnabot.log("kendra settings: " + _.get(event.req["_settings"], "KENDRA_INDEXED_DOCUMENTS_LANGUAGES", ["empty"]));
+    let kendraIndexedLanguages = _.get(event.req["_settings"],
+        "KENDRA_INDEXED_DOCUMENTS_LANGUAGES",["en"]);
+    let origQuestion = event.req["_event"]["origQuestion"];
+    let question = event.req["question"];
+    let userDetectedLocale = event.req["session"]["userDetectedLocale"];
+    let useOriginalLanguageQuery = kendraIndexedLanguages.includes(userDetectedLocale, 0)
+        && origQuestion && question && origQuestion!=question;
+    qnabot.log("useOriginalLanguageQuery: " + useOriginalLanguageQuery);
+
     // This function can handle configuration with an array of kendraIndexes.
     // Iterate through this area and perform queries against Kendra.
     kendraIndexes.forEach(function (index, i) {
@@ -338,7 +343,7 @@ async function routeKendraRequest(event, context) {
             }));
             return;
         }
-        
+
         const params = {
             IndexId: index, /* required */
             QueryText: useOriginalLanguageQuery ? origQuestion: question, /* required */
@@ -397,7 +402,7 @@ async function routeKendraRequest(event, context) {
                     element.AdditionalAttributes.length > 0 &&
                     element.AdditionalAttributes[0].Value.TextWithHighlightsValue.Text) {
                     answerMessage += '\n\n ' + element.AdditionalAttributes[0].Value.TextWithHighlightsValue.Text.replace(/\r?\n|\r/g, " ");
-                    allFilteredMessages.push(answerMessage)                    
+                    allFilteredMessages.push(answerMessage)
                     // Emboldens the highlighted phrases returned by the Kendra response API in markdown format
                     answerTextMd = element.AdditionalAttributes[0].Value.TextWithHighlightsValue.Text.replace(/\r?\n|\r/g, " ");
                     // iterates over the answer highlights in sorted order of BeginOffset, merges the overlapping intervals
@@ -419,7 +424,7 @@ async function routeKendraRequest(event, context) {
                         }
                     }
                     answerMessageMd = answerMessageMd + '\n\n' + answerTextMd;
-                    
+
                     // Shortens the speech response to contain say the longest highlighted phrase ONLY IF top answer not found
                     if (seenTop == false) {
                         var longest_highlight = longestInterval(sorted_highlights);
@@ -430,7 +435,7 @@ async function routeKendraRequest(event, context) {
                         pattern.lastIndex = 0;  // must reset this property of regex object for searches
                         speechMessage = pattern.exec(answerText)[0]
                     }
-                    
+
                     // Convert S3 Object URLs to signed URLs
                     answerDocumentUris.add(element);
                     kendraQueryId = res.QueryId; // store off the QueryId to use as a session attribute for feedback
@@ -438,7 +443,7 @@ async function routeKendraRequest(event, context) {
                     kendraResultId = element.Id; // store off resultId to use as a session attribute for feedback
                     foundAnswerCount++;
                     debug_results.push(create_debug_object(element))
-    
+
 
                 } else if (element.Type === 'QUESTION_ANSWER' && element.AdditionalAttributes && element.AdditionalAttributes.length > 1) {
                     // There will be 2 elements - [0] - QuestionText, [1] - AnswerText
@@ -447,7 +452,7 @@ async function routeKendraRequest(event, context) {
                     }
                     let message = element.AdditionalAttributes[1].Value.TextWithHighlightsValue.Text.replace(/\r?\n|\r/g, " ")
                     answerMessage = faqanswerMessage + '\n\n ' + message;
-                    allFilteredMessages.push(message) 
+                    allFilteredMessages.push(message)
                     seenTop = true; // if the answer is in the FAQ, don't show document extracts
                     answerDocumentUris=[];
                     let answerTextMd = element.AdditionalAttributes[1].Value.TextWithHighlightsValue.Text.replace(/\r?\n|\r/g, " ");
@@ -460,7 +465,7 @@ async function routeKendraRequest(event, context) {
                         answerTextMd = addMarkdownHighlights(answerTextMd, elem.BeginOffset+offset, elem.EndOffset+offset, false) ;
                     }
                     answerMessageMd = faqanswerMessageMd + '\n\n' + answerTextMd;
-                    
+
                     kendraQueryId = res.QueryId; // store off the QueryId to use as a session attribute for feedback
                     kendraIndexId = res.originalKendraIndexId; // store off the Kendra IndexId to use as a session attribute for feedback
                     kendraResultId = element.Id; // store off resultId to use as a session attribute for feedback
@@ -468,7 +473,7 @@ async function routeKendraRequest(event, context) {
                     debug_results.push(create_debug_object(element))
 
 
-                  
+
                 } else if (element.Type === 'DOCUMENT' && element.DocumentExcerpt.Text && element.DocumentURI) {
                     const docInfo = {}
                     // if topAnswer found, then do not show document excerpts
@@ -486,7 +491,7 @@ async function routeKendraRequest(event, context) {
                             let rest = docInfo.text.substr(elem.EndOffset+offset);
                             docInfo.text = beginning + '**' + highlight + '**' + rest;
                         };
-                        
+
                         if (foundAnswerCount == 0 && foundDocumentCount == 0) {
                             speechMessage = element.DocumentExcerpt.Text.replace(/\r?\n|\r/g, " ");;
                             if (sorted_highlights.length > 0) {
@@ -528,13 +533,13 @@ async function routeKendraRequest(event, context) {
         if (speechMessage != "") {
             ssmlMessage = `${speechMessage.substring(0,600).replace(/\r?\n|\r/g, " ")}`;
         }
-        
+
         let lastIndex = ssmlMessage.lastIndexOf('.');
         if (lastIndex > 0) {
             ssmlMessage = ssmlMessage.substring(0,lastIndex);
         }
         ssmlMessage = `<speak> ${ssmlMessage} </speak>`;
-        
+
 
 
     }
@@ -548,7 +553,7 @@ async function routeKendraRequest(event, context) {
          markdown += `<span translate=no>[${element.DocumentTitle.Text}](${element.DocumentURI})</span>`;
       });
     }
-    
+
     let idx=foundAnswerCount;
     if (seenTop == false){
         helpfulDocumentsUris.forEach(function (element) {
@@ -556,7 +561,7 @@ async function routeKendraRequest(event, context) {
                 markdown += `\n\n`;
                 markdown += `***`;
                 markdown += `\n\n <br>`;
-                
+
                 if (element.text && element.text.length > 0 && event.req._preferredResponseType != "SSML") { //don't append doc search to SSML answers
                     markdown += `\n\n  ${element.text}`;
                      message += `\n\n  ${element.text}`;

--- a/lambda/es-proxy-layer/lib/query.js
+++ b/lambda/es-proxy-layer/lib/query.js
@@ -519,10 +519,10 @@ module.exports = async function (req, res) {
         if (_.get(req._settings, 'ENABLE_MULTI_LANGUAGE_SUPPORT')) {
             usrLang = _.get(req, 'session.qnabotcontext.userLocale');
             if (usrLang != 'en' && autotranslate) {
-                console.log("Autotranslate hit to usrLang: ", usrLang);
+                qnabot.log("Autotranslate hit to usrLang: ", usrLang);
                 hit = await translate.translate_hit(hit, usrLang,req);
             } else {
-                console.log("Autotranslate not required.");
+                qnabot.log("Autotranslate not required.");
             }
         }
         // prepend debug msg

--- a/lambda/es-proxy-layer/lib/query.js
+++ b/lambda/es-proxy-layer/lib/query.js
@@ -514,13 +514,15 @@ module.exports = async function (req, res) {
         }
         // translate response
         var usrLang = 'en';
+        const autotranslate = _.get(hit, 'autotranslate', true);
+
         if (_.get(req._settings, 'ENABLE_MULTI_LANGUAGE_SUPPORT')) {
             usrLang = _.get(req, 'session.qnabotcontext.userLocale');
-            if (usrLang != 'en') {
-                qnabot.log("Autotranslate hit to usrLang: ", usrLang);
+            if (usrLang != 'en' && autotranslate) {
+                console.log("Autotranslate hit to usrLang: ", usrLang);
                 hit = await translate.translate_hit(hit, usrLang,req);
             } else {
-                qnabot.log("User Lang is en, Autotranslate not required.");
+                console.log("Autotranslate not required.");
             }
         }
         // prepend debug msg

--- a/templates/master/default-settings.js
+++ b/templates/master/default-settings.js
@@ -35,6 +35,7 @@ var default_settings = {
     KENDRA_INDEXER_CRAWL_MODE: "SUBDOMAINS", // Should be one of 'HOST_ONLY'|'SUBDOMAINS'|'EVERYTHING'
     KENDRA_INDEXER_SCHEDULE: "rate(1 day)",//See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for valid expressions
     KENDRA_WEB_PAGE_INDEX: "${DefaultKendraIndexId}",//The index to use for the web crawler, a custom data source will automatically be added to the specified index.  The index will automatically be added to ALT_SEARCH_KENDRA_INDEXES
+    KENDRA_INDEXED_DOCUMENTS_LANGUAGES: "en", // Comma separated language list, Eg: "en,es,fr". Should be one of supported Kendra languages mentioned in https://docs.aws.amazon.com/kendra/latest/dg/in-adding-languages.html
     ERRORMESSAGE: "Unfortunately I encountered an error when searching for your answer. Please ask me again later.",
     EMPTYMESSAGE: "You stumped me! Sadly I do not know how to answer your question.",
     DEFAULT_ALEXA_LAUNCH_MESSAGE: "Hello, Please ask a question",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Kendra always searches content in English when multi language support is enabled. This does not give the correct URLs and content since only English content will always be translated to the original requested language instead of returning the content/URLs in the requested language itself.
* This change fixes that, discussion notes: https://amzn-wwc.slack.com/archives/C01814Q2LTX/p1649680748980729

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="1791" alt="Screenshot 2022-05-02 at 9 35 02 PM" src="https://user-images.githubusercontent.com/13779547/166412664-a92c2e6a-ce10-4bc0-af46-06bc8dcf00ac.png">
