### PR TITLE
Fix public-vpc-support template adding SingleNode condition.

### DIFF
--- a/templates/public-vpc-support/index.js
+++ b/templates/public-vpc-support/index.js
@@ -106,6 +106,7 @@ module.exports=Promise.resolve(require('../master')).then(function(base){
     base.Conditions.BuildExamples={"Fn::Equals":[true,true]}
     base.Conditions.CreateDomain={"Fn::Equals":[true,true]}
     base.Conditions.DontCreateDomain={"Fn::Equals":[true,false]}
+    base.Conditions.SingleNode={"Fn::Equals":[{"Ref":"ElasticSearchNodeCount"},"1"]}
     base.Conditions.VPCEnabled={ "Fn::Not": [
             { "Fn::Equals": [ "",
                     { "Fn::Join": [ "", { "Ref": "VPCSecurityGroupIdList" } ] }


### PR DESCRIPTION
*Issue #, if available:*
public-vpc-template was not usable from command line CF create/udpate stack.

*Description of changes:*
Add 
```
base.Conditions.SingleNode={"Fn::Equals":[{"Ref":"ElasticSearchNodeCount"},"1"]}
```

To allow proper execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
