### PR TITLE
fixed: QnABot Client not displaying updated languag(es)

### DIFF
--- a/lambda/cfn/lib/ApiDeployment.js
+++ b/lambda/cfn/lib/ApiDeployment.js
@@ -11,7 +11,7 @@ module.exports=class ApiDeployment {
         if(!("ApiDeploymentId" in params))
         {
             run(()=>api.createDeployment(
-                    _.omit(params,["buildDate","stage","Encryption","ApiDeploymentId"])
+                    _.omit(params,["buildDate","stage","Encryption","ApiDeploymentId","LexV2BotLocaleIds"])
                 ).promise()
             )
             .tap(console.log)

--- a/templates/master/config.js
+++ b/templates/master/config.js
@@ -30,7 +30,8 @@ module.exports={
         "restApiId": {"Ref": "API"},
         "buildDate":new Date(),
         "stage":"prod",
-        "Encryption":{"Ref": "Encryption"}
+        "Encryption":{"Ref": "Encryption"}, 
+        "LexV2BotLocaleIds": {"Ref": "LexV2BotLocaleIds"}
     },
     "DependsOn":methods.concat(permissions)
 },


### PR DESCRIPTION
*Issue #, if available:*
During cfn stack update (using current template), a change to the LexV2BotLocaleIds parameter (for example: adding a new language locale) was not initiating a API deployment to Stage, even though the Lex bot was updated with the updated languages. This resulted in the QnABot Client not displaying the updated language option(s) for selection. This case can occur when a cfn stack update is initaited (using the current template). 

*Description of changes:*
The following files were changed to account for the LexV2BotLocaleIds property: 
- /aws-qnabot/lambda/cfn/lib/ApiDeployment.js
- /aws-qnabot/templates/master/config.js

To test this change:
- Update an existing QnABot stack and select {Use current template}
- Change the value of the {LexV2BotLocaleIds} parameter (such as: add a new language)
- Initiate Stack update
- Once the stack update has completed successfully, login to QnABot Designer
- Launch QnABot Client (from the Tools menu)
- Check if the menu option displays the updated languag(es) in QnABot Client

Submitting this pull request for review and next steps. 
