### PR TITLE
Fix kendraredirect queryargs bug

### DIFF
--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -347,7 +347,7 @@ async function routeKendraRequest(event, context) {
             return;
         }
 
-        const params = {
+        let params = {
             IndexId: index, /* required */
             QueryText: useOriginalLanguageQuery ? origQuestion: question, /* required */
         };
@@ -599,7 +599,9 @@ async function routeKendraRequest(event, context) {
         maxDocuments: maxDocumentCount
     })
 
-    hit.autotranslate = useOriginalLanguageQuery ? false : true;
+    if (hit) {
+        hit.autotranslate = useOriginalLanguageQuery ? false : true;
+    }
     qnabot.log("Returning event: ", JSON.stringify(hit, null, 2));
     return hit;
 }


### PR DESCRIPTION
*Issue #, if available:*  N/A

*Description of changes:*

Two small fixes to kendra.js
(1) declare params using 'let' instead of 'const' - since params is updated when argume is provided to kendra redirect quiery
(2) Test if hits is defined before assigning autotranslate member.. hits can be undefined when no results of sufficient confidence are returned by kendra query.

Test case:
(1) define QID with Kendra redirect query and filter, eg 
> Kendra Query Test: What is the cash back rate for this card?
> Kendra query argument: "AttributeFilter": {"EqualsTo": {"Key": "_source_uri", "Value": {"StringValue": "https://www.barclays.co.uk/credit-cards/{{getSlot 'cardtype' ''}}/"}}}
Send utterance to invoke QID

(2) send utterance to invoke no_hits with Kendra Fallback enabled.. Set Kendra fallback condidence hight enough that no hits are returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
