### PR TITLE
Add back URL link to Kendra plaintext message

### DIFF
--- a/lambda/es-proxy-layer/lib/kendra.js
+++ b/lambda/es-proxy-layer/lib/kendra.js
@@ -583,6 +583,7 @@ async function routeKendraRequest(event, context) {
                     element.uri = signS3URL(element.uri, expireSeconds)
                 }
                 markdown += `\n\n  ${helpfulLinksMsg}: <span translate=no>[${label}](${element.uri})</span>`;
+                message += `\n\n  ${helpfulLinksMsg}: ${element.uri}`;
             }
         });
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added source document URL to plain text Kendra Fallback responses (parity with markdown responses)
This got missed somehow in an earlier merge.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
