### PR TITLE
Fix - stopword check breaks multibyte questions / relevance score test fails 

### DIFF
--- a/lambda/es-proxy-layer/lib/es_query.js
+++ b/lambda/es-proxy-layer/lib/es_query.js
@@ -46,7 +46,7 @@ async function run_query_es(req, query_params) {
         method: "GET",
         body: es_query
     });
-    
+
     qnabot.log(`Response from run_query_es => ${JSON.stringify(es_response)}` )
 
     if (_.get(es_response, "hits.hits[0]._source")) {
@@ -91,7 +91,7 @@ async function run_qid_query_es(params, qid) {
 
 function isQuestionAllStopwords(question) {
     let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
-    let questionwords = question.toLowerCase().split(" ")
+    let questionwords = question.toLowerCase().split(/\s+/)
     let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
     return allStopwords;
 }

--- a/lambda/es-proxy-layer/lib/es_query.js
+++ b/lambda/es-proxy-layer/lib/es_query.js
@@ -47,8 +47,14 @@ async function run_query_es(req, query_params) {
         body: es_query
     });
     
+    qnabot.log(`Response from run_query_es => ${JSON.stringify(es_response)}` )
+
     if (_.get(es_response, "hits.hits[0]._source")) {
         _.set(es_response, "hits.hits[0]._source.answersource", "ElasticSearch");
+    }    
+    if (_.get(es_response, "hits.max_score", 0) <= 1) {
+        qnabot.log("Max score is 1 or less - no valid results. Remove hits.")
+        _.set(es_response, "hits.hits", [])
     }
 
     return es_response;
@@ -85,7 +91,7 @@ async function run_qid_query_es(params, qid) {
 
 function isQuestionAllStopwords(question) {
     let stopwords = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with".split(",");
-    let questionwords = question.toLowerCase().match(/\b(\w+)\b/g)
+    let questionwords = question.toLowerCase().split(" ")
     let allStopwords = questionwords.every( x => { return stopwords.includes(x); });
     return allStopwords;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

(1) bug where stopword check breaks multibyte questions   
(2) bug where relevance score test fails dues to baseline score increasing from '0' to '1' due to query changes introduced by another PR   
(3) small logging improvement of query results, and   
(4) avoid needlessly running ES_FALLBACK query if initial query was ES rather than Kendra  



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
